### PR TITLE
Fixed fatal MCP error by changing "instruction" to "instructions"

### DIFF
--- a/sqlite_reader_mcp/__main__.py
+++ b/sqlite_reader_mcp/__main__.py
@@ -11,7 +11,7 @@ allowed_files: list[Path] = []
 
 mcp = FastMCP(
     name="SQLite MCP Server",
-    instruction="This server allows read-only access to SQLite databases.",
+    instructions="This server allows read-only access to SQLite databases.",
     log_level="CRITICAL",
 )
 


### PR DESCRIPTION
Fixed Fatal MCP Error

<img width="1153" height="190" alt="image" src="https://github.com/user-attachments/assets/3f0b2cc8-52e7-42b4-81e9-155d918fbcec" />
